### PR TITLE
Fix kurmak.info link

### DIFF
--- a/index.html
+++ b/index.html
@@ -462,7 +462,7 @@
 			<div class="content">
 				<h2>Курсы</h2>
 				<ul class="ul-left">
-					<li class="next"><a href="kurmak.info">Курс по цифровой доступности (Валерия Курмак)</a></li>
+					<li class="next"><a href="https://kurmak.info">Курс по цифровой доступности (Валерия Курмак)</a></li>
 					<li class="next"><a href="https://www.w3.org/WAI/fundamentals/foundations-course/">Бесплатный курс от Web Accessibility Initiative</a></li>
 					<li class="next"><a href="https://www.deque.com/training/">Курс от Deque</a></li>
 					<li class="next"><a href="https://www.digitala11y.com/digital-accessibility-courses-roundup/">Список платных и бесплатных курсов по доступности</a></li>


### PR DESCRIPTION
Without `https://` this link leads to https://lenaryan.github.io/state-of-a11y-2023/kurmak.info.